### PR TITLE
docs: update readme for weather app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,49 @@
-# create-svelte
+# My Svelte Weather
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
+My Svelte Weather is an interactive weather forecast application built with SvelteKit, Tailwind CSS, and Leaflet. It retrieves 36-hour forecasts from Taiwan's Central Weather Administration and displays them on an interactive map.
 
-## Creating a project
+## Features
 
-If you're seeing this, you've probably already done this step. Congrats!
+- Browse Taiwan's cities on an interactive map
+- View detailed 36-hour forecast for a selected city, including temperature and conditions
+- Built with SvelteKit, TypeScript and Tailwind CSS
 
-```bash
-# create a new project in the current directory
-npm create svelte@latest
+## Setup
 
-# create a new project in my-app
-npm create svelte@latest my-app
-```
+1. Install dependencies:
 
-## Developing
+   ```bash
+   yarn install
+   ```
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+2. Create a `.env` file in the project root with your CWA API token:
 
-```bash
-npm run dev
+   ```
+   PUBLIC_API_TOKEN=your_token_here
+   ```
 
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
+## Development
 
-## Building
-
-To create a production version of your app:
+Start a development server at <http://localhost:5173>:
 
 ```bash
-npm run build
+yarn dev
 ```
 
-You can preview the production build with `npm run preview`.
+Use `yarn dev --open` to open the app in a new browser tab.
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+## Production
+
+Create an optimized production build:
+
+```bash
+yarn build
+```
+
+Preview the production build locally:
+
+```bash
+yarn preview
+```
+
+To deploy to a specific environment, install the appropriate [SvelteKit adapter](https://kit.svelte.dev/docs/adapters).

--- a/README.md
+++ b/README.md
@@ -1,49 +1,61 @@
 # My Svelte Weather
 
-My Svelte Weather is an interactive weather forecast application built with SvelteKit, Tailwind CSS, and Leaflet. It retrieves 36-hour forecasts from Taiwan's Central Weather Administration and displays them on an interactive map.
+## 專案簡介
 
-## Features
+My Svelte Weather 是一個使用 SvelteKit 建置的互動式天氣預報網站，提供台灣各縣市未來 36 小時的氣象資訊，並透過地圖介面呈現。
 
-- Browse Taiwan's cities on an interactive map
-- View detailed 36-hour forecast for a selected city, including temperature and conditions
-- Built with SvelteKit, TypeScript and Tailwind CSS
+## 主要功能
 
-## Setup
+- 於 Leaflet 地圖上瀏覽並選取各縣市
+- 顯示所選縣市的 36 小時預報：溫度、降雨機率與天氣現象
+- 介面以 SvelteKit、TypeScript 與 Tailwind CSS 打造
 
-1. Install dependencies:
+## 技術架構
 
+### 前端技術棧
+
+- SvelteKit
+- TypeScript
+- Tailwind CSS
+- Leaflet
+
+### 後端技術棧
+
+- Node.js 與 SvelteKit 伺服器端渲染
+- 透過 `fetch` 連線中央氣象局（CWA）開放資料 API
+
+### 架構設計
+
+前端直接向 CWA API 取得資料，SvelteKit 負責路由與 API Token 的伺服器端注入，架構簡潔易部署。
+
+## 專案結構
+
+```
+.
+├── src/
+│   ├── lib/          # 共用元件與工具
+│   └── routes/       # 應用頁面
+├── static/           # 靜態資源
+├── tests/            # Playwright 測試
+└── ...               # 其他設定檔案
+```
+
+## 快速開始
+
+1. 安裝依賴
    ```bash
    yarn install
    ```
-
-2. Create a `.env` file in the project root with your CWA API token:
-
-   ```
+2. 在專案根目錄建立 `.env` 並設定中央氣象局 API Token
+   ```bash
    PUBLIC_API_TOKEN=your_token_here
    ```
-
-## Development
-
-Start a development server at <http://localhost:5173>:
-
-```bash
-yarn dev
-```
-
-Use `yarn dev --open` to open the app in a new browser tab.
-
-## Production
-
-Create an optimized production build:
-
-```bash
-yarn build
-```
-
-Preview the production build locally:
-
-```bash
-yarn preview
-```
-
-To deploy to a specific environment, install the appropriate [SvelteKit adapter](https://kit.svelte.dev/docs/adapters).
+3. 啟動開發伺服器 <http://localhost:5173>
+   ```bash
+   yarn dev
+   ```
+4. 建置與預覽生產版
+   ```bash
+   yarn build
+   yarn preview
+   ```


### PR DESCRIPTION
## Summary
- document Taiwan weather app features and setup

## Testing
- `yarn lint` *(fails: '$$Events' is defined but never used)*
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1105/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68956414a9d88330b8c151abdb52531e