### PR TITLE
Add unit tests for fetchWeatherData

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3);
-	});
-});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -9,11 +9,12 @@ import axios from 'axios';
 import { fetchWeatherData } from './api';
 
 const mockedAxios = vi.mocked(axios);
+const mockedAxiosGet = vi.mocked(axios.get);
 
 describe('fetchWeatherData', () => {
 	it('calls API with token and returns data', async () => {
 		const mockData = { foo: 'bar' };
-		mockedAxios.get.mockResolvedValue({ data: mockData });
+		mockedAxiosGet.mockResolvedValue({ data: mockData });
 
 		const result = await fetchWeatherData();
 
@@ -26,7 +27,7 @@ describe('fetchWeatherData', () => {
 
 	it('logs and rethrows errors', async () => {
 		const error = new Error('Network error');
-		mockedAxios.get.mockRejectedValue(error);
+		mockedAxiosGet.mockRejectedValue(error);
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		await expect(fetchWeatherData()).rejects.toThrow(error);

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('axios');
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_API_TOKEN: 'TEST_TOKEN' }
+}));
+
+import axios from 'axios';
+import { fetchWeatherData } from './api';
+
+const mockedAxios = vi.mocked(axios);
+
+describe('fetchWeatherData', () => {
+	it('calls API with token and returns data', async () => {
+		const mockData = { foo: 'bar' };
+		mockedAxios.get.mockResolvedValue({ data: mockData });
+
+		const result = await fetchWeatherData();
+
+		expect(mockedAxios.get).toHaveBeenCalledWith(
+			'https://opendata.cwa.gov.tw/api/v1/rest/datastore/F-C0032-001',
+			{ params: { Authorization: 'TEST_TOKEN' } }
+		);
+		expect(result).toEqual({ data: mockData });
+	});
+
+	it('logs and rethrows errors', async () => {
+		const error = new Error('Network error');
+		mockedAxios.get.mockRejectedValue(error);
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(fetchWeatherData()).rejects.toThrow(error);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching weather data:', error);
+
+		consoleErrorSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary
- add tests for fetchWeatherData success path and error handling

## Testing
- `yarn test:unit`
- `npx prettier --check src/lib/api.test.ts`
- `npx eslint src/lib/api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895643db7cc8330a2eedb4cc4d0a95d