### PR TITLE
refactor: extract map and weather card

### DIFF
--- a/src/lib/components/WeatherRangeCard.svelte
+++ b/src/lib/components/WeatherRangeCard.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import type { WeatherTimeElement } from '@/weatherType';
+	export let range: WeatherTimeElement;
+</script>
+
+<Card.Root>
+	<Card.Header>
+		<Card.Title>{`${range.startTime}~${range.endTime}`}</Card.Title>
+	</Card.Header>
+	<Card.Content>
+		<ul>
+			<li>天氣現象：{range.Wx?.parameterName}</li>
+			<li>降雨機率：{range.Pop ? `${range.Pop.parameterName}${range.Pop.parameterUnit}` : ''}</li>
+			<li>最高溫：{range.MaxT ? `${range.MaxT.parameterName}°C` : ''}</li>
+			<li>低溫：{range.MinT ? `${range.MinT.parameterName}°C` : ''}</li>
+			<li>舒適度：{range.CI?.parameterName}</li>
+		</ul>
+	</Card.Content>
+</Card.Root>

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -1,0 +1,47 @@
+import L, { FeatureGroup } from 'leaflet';
+import type { Feature, GeoJsonObject } from 'geojson';
+
+export const initialView = { lat: 23.5283, lng: 120.9795 };
+
+export const createMap = (container: HTMLDivElement) => {
+	const map = L.map(container, { preferCanvas: true }).setView(initialView, 8);
+	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		maxZoom: 19,
+		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+	}).addTo(map);
+	return map;
+};
+
+export const bindFeatureEvents = (
+	feature: Feature,
+	layer: FeatureGroup,
+	onCityClick: (city: string) => void
+) => {
+	if (feature.properties) {
+		const cityName = feature.properties.NAME_2014;
+		layer.bindTooltip(cityName);
+		layer.on('mouseover', () => {
+			layer.setStyle({ fillColor: '#0000ff' });
+		});
+		layer.on('mouseout', () => {
+			layer.setStyle({ fillColor: 'transparent', className: 'myListener ' });
+		});
+		layer.on('click', () => {
+			console.log('cityName', cityName);
+			onCityClick(cityName);
+		});
+	}
+};
+
+export const addGeoLayer = (
+	map: L.Map,
+	geo: GeoJsonObject,
+	onCityClick: (city: string) => void
+): L.GeoJSON => {
+	const layer = L.geoJSON(geo as GeoJsonObject, {
+		onEachFeature: (feature, l) => bindFeatureEvents(feature, l as FeatureGroup, onCityClick),
+		style: { fillColor: 'transparent' }
+	});
+	layer.addTo(map);
+	return layer;
+};


### PR DESCRIPTION
## Summary
- extract weather range presentation into component
- move map helpers to dedicated module
- simplify page by using new utilities

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68958e78db1483309c9372566aeb564f